### PR TITLE
fix: Fixed issue with page size calculation in graphql queries.

### DIFF
--- a/src/asset-swapper/utils/market_operation_utils/pools_cache/pool_list_cache.ts
+++ b/src/asset-swapper/utils/market_operation_utils/pools_cache/pool_list_cache.ts
@@ -73,7 +73,7 @@ export const fetchPoolLists = async (page: number, pageSize: number, createdBy: 
     graphUrl,
     queryPools(
       (Math.max(page - 1, 0) * pageSize) / 2, // Because there are 2 rows (long and short) in the table for every pool
-      pageSize,
+      pageSize / 2, // Because there are 2 rows (long and short) in the table for every pool
       createdBy,
       undefined
     )

--- a/src/services/orderbook_service.ts
+++ b/src/services/orderbook_service.ts
@@ -430,9 +430,7 @@ export class OrderBookService {
                 pool.baseToken,
                 pool.quoteToken
             );
-            // const bidApiOrders = await this.getOrderBookAsync(1, 1000, pool.baseToken, pool.quoteToken);
-            // // Get ask list using pool's baseToken and quoteToken
-            // const askApiOrders = await this.getOrderBookAsync(1, 1000, pool.quoteToken, pool.baseToken);
+            // Get ask list using pool's baseToken and quoteToken
             pool.bids = bidApiOrders;
             pool.asks = askApiOrders;
 


### PR DESCRIPTION
- Fixed issue with page size calculation in graphql queries.
  If the page size is 100, the table will show 50 pool rows. This is because every pool has 2 rows (long row and short row). So we have to compute it in the graphql query.